### PR TITLE
Grid Ops Fixes

### DIFF
--- a/lib/actions.lua
+++ b/lib/actions.lua
@@ -5,9 +5,9 @@ local actions = {
   edit_step = 'edit_step',
   disply_note = 'display_note',
   play_note = 'play_note',
+  set_error_message = 'set_error_message',
   set_observer_position = 'set_observer_position',
   set_source_positions = 'set_source_positions',
-  toggle_error_takeover = 'toggle_error_takeover',
   toggle_sequence = 'toggle_sequence',
   update_arrangement_status = 'update_arrangement_status'
 }

--- a/lib/actions.lua
+++ b/lib/actions.lua
@@ -7,6 +7,7 @@ local actions = {
   play_note = 'play_note',
   set_observer_position = 'set_observer_position',
   set_source_positions = 'set_source_positions',
+  toggle_error_takeover = 'toggle_error_takeover',
   toggle_sequence = 'toggle_sequence',
   update_arrangement_status = 'update_arrangement_status'
 }

--- a/lib/arrangement.lua
+++ b/lib/arrangement.lua
@@ -113,6 +113,10 @@ function Arrangement:press(k, z)
   end
 end
 
+function Arrangement:turn(n, delta)
+  self:_ring_input_to_sequence(n, delta)
+end
+
 function Arrangement:twist(e, delta)
   if e == 1 and not shift_depressed then
     local mode = get_current_mode()
@@ -164,9 +168,7 @@ function Arrangement:_init_observers()
 end
 
 function Arrangement:_init_rings()
-  local rings = Rings:new({
-    delta = function(n, delta) self:_ring_input_to_sequence(n, delta) end
-  })
+  local rings = Rings:new()
   for i = 1, self.sequences:size() do
     local sequence = self.sequences:get_sequence(i)
     rings:add(Ring:new({

--- a/lib/arrangement.lua
+++ b/lib/arrangement.lua
@@ -113,10 +113,6 @@ function Arrangement:press(k, z)
   end
 end
 
-function Arrangement:turn(n, delta)
-  self:_ring_input_to_sequence(n, delta)
-end
-
 function Arrangement:twist(e, delta)
   if e == 1 and not shift_depressed then
     local mode = get_current_mode()
@@ -168,7 +164,9 @@ function Arrangement:_init_observers()
 end
 
 function Arrangement:_init_rings()
-  local rings = Rings:new()
+  local rings = Rings:new({
+    delta = function(n, delta) self:_ring_input_to_sequence(n, delta) end
+  })
   for i = 1, self.sequences:size() do
     local sequence = self.sequences:get_sequence(i)
     rings:add(Ring:new({

--- a/lib/arrangement/rings.lua
+++ b/lib/arrangement/rings.lua
@@ -13,6 +13,7 @@ end
 
 function Rings:init(n)
   self.host = arc.connect(n)
+  self.host.delta = arc_delta
   for _, ring in pairs(self.rings) do
     ring:set('host', self.host)
   end

--- a/lib/arrangement/rings.lua
+++ b/lib/arrangement/rings.lua
@@ -1,5 +1,6 @@
 local Rings = {
   context = nil,
+  delta = nil,
   host = nil,
   rings = {}
 }
@@ -13,7 +14,7 @@ end
 
 function Rings:init(n)
   self.host = arc.connect(n)
-  self.host.delta = arc_delta
+  self.host.delta = self.delta
   for _, ring in pairs(self.rings) do
     ring:set('host', self.host)
   end

--- a/lib/arrangement/rings.lua
+++ b/lib/arrangement/rings.lua
@@ -1,6 +1,5 @@
 local Rings = {
   context = nil,
-  delta = nil,
   host = nil,
   rings = {}
 }
@@ -14,7 +13,7 @@ end
 
 function Rings:init(n)
   self.host = arc.connect(n)
-  self.host.delta = self.delta
+  self.host.delta = arc_delta
   for _, ring in pairs(self.rings) do
     ring:set('host', self.host)
   end

--- a/lib/chart.lua
+++ b/lib/chart.lua
@@ -43,7 +43,7 @@ function Chart:hydrate(chart)
 end
 
 function Chart:init(n)
-  self.host = grid.connect(n)
+  self:set_grid(n)
   self:_init_plans()
   self:_init_pages()
 end
@@ -54,6 +54,14 @@ end
 
 function Chart:set(k, v)
   self[k] = v
+end
+
+function Chart:set_grid(n)
+  self.host = grid.connect(n)
+  if self.host.cols == 0 then
+    set_current_mode(ERROR)
+    self.affect_console(actions.toggle_error_takeover, 1)
+  end
 end
 
 function Chart:press(x, y, z)
@@ -73,7 +81,6 @@ function Chart:step()
   self:_step_count()
 end
 
-
 function Chart:affect(action, index, values)
   if action == actions.emit_pulse then
     local sequence = index
@@ -88,9 +95,17 @@ function Chart:affect(action, index, values)
   end
 end
 
+function Chart:refresh_pages()
+  -- TODO validate that we actually instantiated a new grid
+  for i = 1, #self.panels do
+    self.panels[i].led = '' -- Finish
+  end
+  self:_init_pages()
+end
+
 function Chart:_init_pages()
-  local chart_height = self.host.rows
-  local chart_width = self.host.cols
+  local chart_height = self.host.rows or PANE_EDGE_LENGTH
+  local chart_width = self.host.cols or PANE_EDGE_LENGTH
   local page_count = 1
   local pages = {}
   local panes_per_page = 4

--- a/lib/chart.lua
+++ b/lib/chart.lua
@@ -59,9 +59,7 @@ end
 function Chart:set_grid(n)
   self.host = grid.connect(n)
   self.host.key = function(x, y, z) chart:press(x, y, z) end
-  print(self.host, self.host.cols, self.host.rows)
   if self.plans then
-    print('INIT OPAGES', self.plans, #self.plans)
     self:_init_pages()
   end
 end
@@ -98,6 +96,7 @@ function Chart:affect(action, index, values)
 end
 
 function Chart:_init_pages()
+  self.page = 1
   local rows = self.host.rows
   local cols = self.host.cols
   local chart_height = rows ~= 0 and rows or PANE_EDGE_LENGTH

--- a/lib/chart.lua
+++ b/lib/chart.lua
@@ -58,6 +58,7 @@ end
 
 function Chart:set_grid(n)
   self.host = grid.connect(n)
+  self.host.key = grid_key
   if self.host.cols == 0 then
     set_current_mode(ERROR)
     self.affect_console(actions.toggle_error_takeover, 1)

--- a/lib/chart.lua
+++ b/lib/chart.lua
@@ -58,12 +58,16 @@ end
 
 function Chart:set_grid(n)
   self.host = grid.connect(n)
-  self.host.key = function(x, y, z) chart:press(x, y, z) end
-  print(self.host, self.host.cols, self.host.rows)
+  self.host.key = grid_key
   if self.plans then
-    print('INIT OPAGES', self.plans, #self.plans)
     self:_init_pages()
   end
+  -- if self.host.cols == 0 then
+  --   set_current_mode(ERROR)
+  --   self.affect_console(actions.set_error_message, 1)
+  -- elseif get_current_mode() == ERROR then
+  --   set_current_mode(DEFAULT)
+  -- end
 end
 
 function Chart:press(x, y, z)
@@ -105,13 +109,6 @@ function Chart:_init_pages()
   local page_count = 1
   local pages = {}
   local panes_per_page = 4
-  local function led(x, y, l)
-    if self.host.cols == PANE_EDGE_LENGTH then
-      -- Monobrite for 64s
-      l = 15
-    end
-    self.host:led(x, y, l)
-  end
   
   if chart_height == PANE_EDGE_LENGTH then
     if chart_width == PANE_EDGE_LENGTH then
@@ -136,7 +133,7 @@ function Chart:_init_pages()
         offset = i - 1
       end
       local pane = Pane:new({pane = j, plan = self.plans[j + offset]})
-      pane:init(panes_per_page, led)
+      pane:init(panes_per_page)
       table.insert(panes, pane)
     end
     
@@ -149,21 +146,33 @@ function Chart:_init_pages()
 end
 
 function Chart:_init_plans()
+  local function led(x, y, l)
+    if self.host.cols == PANE_EDGE_LENGTH then
+      -- Monobrite for 64s
+      l = 15
+    end
+    self.host:led(x, y, l)
+  end
+
   local plans = {
     RadiationPlan:new({
+      led = led,
       name = RADIATION_PLAN,
       affect_arrangement = self.affect_arrangement,
       affect_ensemble = self.affect_ensemble
     }),
     PathPlan:new({
+      led = led,
       name = PATH_PLAN,
       affect_ensemble = self.affect_ensemble
     }),
     CatPlan:new({
+      led = led,
       name = CAT_PLAN,
       affect_ensemble = self.affect_ensemble
     }),
     ReliefPlan:new({
+      led = led,
       name = RELIEF_PLAN
     })
   }

--- a/lib/chart.lua
+++ b/lib/chart.lua
@@ -58,16 +58,12 @@ end
 
 function Chart:set_grid(n)
   self.host = grid.connect(n)
-  self.host.key = grid_key
+  self.host.key = function(x, y, z) chart:press(x, y, z) end
+  print(self.host, self.host.cols, self.host.rows)
   if self.plans then
+    print('INIT OPAGES', self.plans, #self.plans)
     self:_init_pages()
   end
-  -- if self.host.cols == 0 then
-  --   set_current_mode(ERROR)
-  --   self.affect_console(actions.set_error_message, 1)
-  -- elseif get_current_mode() == ERROR then
-  --   set_current_mode(DEFAULT)
-  -- end
 end
 
 function Chart:press(x, y, z)
@@ -109,6 +105,13 @@ function Chart:_init_pages()
   local page_count = 1
   local pages = {}
   local panes_per_page = 4
+  local function led(x, y, l)
+    if self.host.cols == PANE_EDGE_LENGTH then
+      -- Monobrite for 64s
+      l = 15
+    end
+    self.host:led(x, y, l)
+  end
   
   if chart_height == PANE_EDGE_LENGTH then
     if chart_width == PANE_EDGE_LENGTH then
@@ -133,7 +136,7 @@ function Chart:_init_pages()
         offset = i - 1
       end
       local pane = Pane:new({pane = j, plan = self.plans[j + offset]})
-      pane:init(panes_per_page)
+      pane:init(panes_per_page, led)
       table.insert(panes, pane)
     end
     
@@ -146,33 +149,21 @@ function Chart:_init_pages()
 end
 
 function Chart:_init_plans()
-  local function led(x, y, l)
-    if self.host.cols == PANE_EDGE_LENGTH then
-      -- Monobrite for 64s
-      l = 15
-    end
-    self.host:led(x, y, l)
-  end
-
   local plans = {
     RadiationPlan:new({
-      led = led,
       name = RADIATION_PLAN,
       affect_arrangement = self.affect_arrangement,
       affect_ensemble = self.affect_ensemble
     }),
     PathPlan:new({
-      led = led,
       name = PATH_PLAN,
       affect_ensemble = self.affect_ensemble
     }),
     CatPlan:new({
-      led = led,
       name = CAT_PLAN,
       affect_ensemble = self.affect_ensemble
     }),
     ReliefPlan:new({
-      led = led,
       name = RELIEF_PLAN
     })
   }

--- a/lib/chart.lua
+++ b/lib/chart.lua
@@ -19,8 +19,8 @@ local Chart = {
   host = nil,
   lumen = 5,
   page = 1,
-  pages = {},
-  plans = {}
+  pages = nil,
+  plans = nil
 }
 
 function Chart:new(options)
@@ -59,10 +59,15 @@ end
 function Chart:set_grid(n)
   self.host = grid.connect(n)
   self.host.key = grid_key
-  if self.host.cols == 0 then
-    set_current_mode(ERROR)
-    self.affect_console(actions.toggle_error_takeover, 1)
+  if self.plans then
+    self:_init_pages()
   end
+  -- if self.host.cols == 0 then
+  --   set_current_mode(ERROR)
+  --   self.affect_console(actions.set_error_message, 1)
+  -- elseif get_current_mode() == ERROR then
+  --   set_current_mode(DEFAULT)
+  -- end
 end
 
 function Chart:press(x, y, z)
@@ -96,17 +101,11 @@ function Chart:affect(action, index, values)
   end
 end
 
-function Chart:refresh_pages()
-  -- TODO validate that we actually instantiated a new grid
-  for i = 1, #self.panels do
-    self.panels[i].led = '' -- Finish
-  end
-  self:_init_pages()
-end
-
 function Chart:_init_pages()
-  local chart_height = self.host.rows or PANE_EDGE_LENGTH
-  local chart_width = self.host.cols or PANE_EDGE_LENGTH
+  local rows = self.host.rows
+  local cols = self.host.cols
+  local chart_height = rows ~= 0 and rows or PANE_EDGE_LENGTH
+  local chart_width = cols ~= 0 and cols or PANE_EDGE_LENGTH
   local page_count = 1
   local pages = {}
   local panes_per_page = 4

--- a/lib/chart/pane.lua
+++ b/lib/chart/pane.lua
@@ -10,10 +10,11 @@ function Pane:new(options)
   return instance
 end
 
-function Pane:init(panes_per_page)
+function Pane:init(panes_per_page, led)
   if not self.plan:get('features') then
     self.plan:init()
   end
+  self.plan:set('led', led)
   self:update_offsets(panes_per_page)
 end
 

--- a/lib/chart/pane.lua
+++ b/lib/chart/pane.lua
@@ -40,6 +40,7 @@ function Pane:update_offsets(panes_per_page)
   local x_offset, y_offset = self:_determine_offsets(panes_per_page)
   self.plan:set('x_offset', x_offset)
   self.plan:set('y_offset', y_offset)
+  self.plan:update_symbol_offsets()
 end
 
 function Pane:get_offsets()

--- a/lib/chart/pane.lua
+++ b/lib/chart/pane.lua
@@ -10,11 +10,10 @@ function Pane:new(options)
   return instance
 end
 
-function Pane:init(panes_per_page, led)
+function Pane:init(panes_per_page)
   if not self.plan:get('features') then
     self.plan:init()
   end
-  self.plan:set('led', led)
   self:update_offsets(panes_per_page)
 end
 

--- a/lib/chart/pane.lua
+++ b/lib/chart/pane.lua
@@ -11,7 +11,9 @@ function Pane:new(options)
 end
 
 function Pane:init(panes_per_page)
-  self.plan:init()
+  if not self.plan:get('features') then
+    self.plan:init()
+  end
   self:update_offsets(panes_per_page)
 end
 

--- a/lib/chart/plan.lua
+++ b/lib/chart/plan.lua
@@ -68,6 +68,18 @@ function Plan:reset()
   self:init()
 end
 
+function Plan:update_symbol_offsets()
+  for c = 1, PANE_EDGE_LENGTH do
+    for r = 1, PANE_EDGE_LENGTH do
+      local feature = self.features[c][r]
+      if feature then
+        feature:set('x_offset', self.x_offset)
+        feature:set('y_offset', self.y_offset)
+      end
+    end
+  end
+end
+
 function Plan:_add(x, y)
   local symbol = {
     led = self.led,

--- a/lib/console.lua
+++ b/lib/console.lua
@@ -1,4 +1,5 @@
 local actions = include('lib/actions')
+local ErrorScreen = include('lib/console/error_screen')
 local InfoScreen = include('lib/console/info_screen')
 local SequenceScreen = include('lib/console/sequence_screen')
 local StepScreen = include('lib/console/step_screen')
@@ -56,7 +57,9 @@ function Console:refresh()
   if self.dirty then
     local mode = MODES[current_mode()]
     screen.clear()
-    if mode == DEFAULT then
+    if mode == ERROR then
+      self.screens[ERROR]:draw()
+    elseif mode == DEFAULT then
       local default_console_mode = DEFAULT_CONSOLE_MODES[self.default_mode]
       if parameters.animations_enabled() and default_console_mode == ANIMATION then
         local filepath = SPRITE_PATH..ANIMATION_SCENES[self.animation_scene]..'/'..self.animation_cell..'.png'
@@ -94,6 +97,8 @@ function Console:affect(action, index, values)
     self.screens[SEQUENCE]:update(index, values)
   elseif action == actions.edit_step then
     self.screens[STEP]:update(index, values)
+  elseif action == actions.toggle_error_takeover then
+    self.screens[ERROR]:update(index)
   end
 
   self.dirty = true
@@ -116,6 +121,7 @@ end
 
 function Console:_init_screens()
   self.screens = {
+    [ERROR] = ErrorScreen:new(),
     [INFO] = InfoScreen:new(),
     [SEQUENCE] = SequenceScreen:new(),
     [STEP] = StepScreen:new()

--- a/lib/console.lua
+++ b/lib/console.lua
@@ -97,7 +97,7 @@ function Console:affect(action, index, values)
     self.screens[SEQUENCE]:update(index, values)
   elseif action == actions.edit_step then
     self.screens[STEP]:update(index, values)
-  elseif action == actions.toggle_error_takeover then
+  elseif action == actions.set_error_message then
     self.screens[ERROR]:update(index)
   end
 

--- a/lib/console/error_screen.lua
+++ b/lib/console/error_screen.lua
@@ -20,6 +20,8 @@ function ErrorScreen:new(options)
 end
 
 function ErrorScreen:draw()
+  screen.font_face(console_constants.FONTS.BASIC.FACE)
+  screen.font_size(console_constants.FONTS.BASIC.SIZE)
   screen.move(X_RULE, Y_RULE)
   screen.text_center(ERRORS[self.error_index])
 end

--- a/lib/console/error_screen.lua
+++ b/lib/console/error_screen.lua
@@ -1,0 +1,31 @@
+local console_constants = include('lib/console/constants')
+local Screen = include('lib/console/screen')
+
+local ERRORS = {
+  'Please connect a grid'
+}
+local X_RULE = console_constants.SCREEN_WIDTH / 2
+local Y_RULE = console_constants.SCREEN_HEIGHT / 2
+
+local ErrorScreen = {
+  error_index = 0
+}
+
+function ErrorScreen:new(options)
+  local instance = options or {}
+  setmetatable(self, {__index = Screen})
+  setmetatable(instance, self)
+  self.__index = self
+  return instance
+end
+
+function ErrorScreen:draw()
+  screen.move(X_RULE, Y_RULE)
+  screen.text_center(ERRORS[self.error_index])
+end
+
+function ErrorScreen:update(i)
+  self.error_index = i
+end
+
+return ErrorScreen

--- a/marcovaldo.lua
+++ b/marcovaldo.lua
@@ -134,11 +134,11 @@ function key(k, z)
   end
 end
 
-function arc.delta(n, delta)
+function arc_delta(n, delta)
   arrangement:turn(n, delta)
 end
 
-function grid.key(x, y, z)
+function grid_key(x, y, z)
   chart:press(x, y, z)
 end
 

--- a/marcovaldo.lua
+++ b/marcovaldo.lua
@@ -224,7 +224,7 @@ end
 function grid.add(added)
   chart:set_grid(added.port)
 end
-
+  
 function grid.remove(removed)
   chart:set_grid()
 end

--- a/marcovaldo.lua
+++ b/marcovaldo.lua
@@ -136,22 +136,6 @@ function key(k, z)
   end
 end
 
-function arc_delta(n, delta)
-  arrangement:turn(n, delta)
-end
-
-function grid_key(x, y, z)
-  chart:press(x, y, z)
-end
-
-function grid.add(added)
-  chart:set_grid(added.port)
-end
-
-function grid.remove(removed)
-  chart:set_grid()
-end
-
 function default_mode_timeout_cancel()
   if default_mode_timeout then
     clock.cancel(default_mode_timeout)
@@ -235,4 +219,12 @@ end
 
 function refresh()
   console:refresh()
+end
+
+function grid.add(added)
+  chart:set_grid(added.port)
+end
+
+function grid.remove(removed)
+  chart:set_grid()
 end

--- a/marcovaldo.lua
+++ b/marcovaldo.lua
@@ -123,6 +123,8 @@ function key(k, z)
   if k == 2 and z == 0 and not shift_depressed then
     if mode == SEQUENCE then
       set_current_mode(DEFAULT)
+    elseif mode == ERROR then
+      set_current_mode(DEFAULT)
     else
       arrangement:press(k, z)
     end
@@ -143,19 +145,11 @@ function grid_key(x, y, z)
 end
 
 function grid.add(added)
-  if self.host.cols == 0 then
-    chart:set_grid(added.port)
-    chart:refresh_pages()
-    set_current_mode(DEFAULT)
-  end
+  chart:set_grid(added.port)
 end
 
 function grid.remove(removed)
-  if self.host.port == removed.port then
-    chart:set_grid()
-    set_current_mode(ERROR)
-    self.affect_console(actions.toggle_error_takeover, 1)
-  end
+  chart:set_grid()
 end
 
 function default_mode_timeout_cancel()

--- a/marcovaldo.lua
+++ b/marcovaldo.lua
@@ -136,6 +136,22 @@ function key(k, z)
   end
 end
 
+function arc_delta(n, delta)
+  arrangement:turn(n, delta)
+end
+
+function grid_key(x, y, z)
+  chart:press(x, y, z)
+end
+
+function grid.add(added)
+  chart:set_grid(added.port)
+end
+
+function grid.remove(removed)
+  chart:set_grid()
+end
+
 function default_mode_timeout_cancel()
   if default_mode_timeout then
     clock.cancel(default_mode_timeout)
@@ -219,12 +235,4 @@ end
 
 function refresh()
   console:refresh()
-end
-
-function grid.add(added)
-  chart:set_grid(added.port)
-end
-
-function grid.remove(removed)
-  chart:set_grid()
 end


### PR DESCRIPTION
Includes fixes for midigrid enablement and loading without grid attached. Additionally allows for swapping of grids with chart rescaling.